### PR TITLE
Add ability to run markdown on multiple separate elements.

### DIFF
--- a/demos/multiple-markdown-sections.html
+++ b/demos/multiple-markdown-sections.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Strapdown.js - Instant and elegant Markdown documents</title>
+  <meta name="description" content="Create Markdown documents using JavaScript and Bootstrap themes" />
+</script>
+</head>
+
+<body>
+
+<textarea theme="united" style="display:none;" id="preserve-me">
+## Markdown 1
+
+Check <strong>HTML</strong> <em>tags</em> <u>still</u> work.
+</textarea>
+
+<div>Regular content with a <textarea class="strapdown-ignore" cols="8" rows="1" style="display: inline-block;">textarea</textarea> we want Strapdown.js to ignore.</div>
+
+<xmp theme="united" style="display:none;">
+## Markdown 2
+
+````
+<textarea>Textarea as code sample.</textarea>
+````
+
+Check <strong>HTML</strong> <em>tags</em> <u>still</u> work.
+</xmp>
+
+<div>Regular content with an <xmp class="strapdown-ignore" style="display: inline-block;">xmp</xmp> we want Strapdown.js to ignore.</div>
+
+<textarea theme="united" style="display:none;">
+## Markdown 3
+
+Check <strong>HTML</strong> <em>tags</em> <u>still</u> work.
+</textarea>
+
+<script src="../v/0.3/strapdown.js"></script>
+
+</body>
+</html>

--- a/src/strapdown.css
+++ b/src/strapdown.css
@@ -16,6 +16,10 @@ xmp, textarea {
   display: none;
 }
 
+xmp.strapdown-ignore, textarea.strapdown-ignore {
+  display: block;
+}
+
 h1,h2,h3,h4 {
   margin: 15px 0;
 }

--- a/src/strapdown.js
+++ b/src/strapdown.js
@@ -24,19 +24,38 @@
     }
   }
 
+  var htmlCollectionToArray = (function () {
+    function toArr(coll) {
+      var arr = [],
+          i,
+          len = coll.length;
+      for (i = 0; i < len; i++) {
+        arr.push(coll[i]);
+      }
+      return arr;
+    }
+    return function (coll) {
+      try {
+        return Array.prototype.slice.call(coll, 0);
+      } catch (e) {
+        // E.g. IE8 fails using slice.
+        // http://stackoverflow.com/a/2735133/319878
+        return toArr(coll);
+      }
+    };
+  }());
+
   //////////////////////////////////////////////////////////////////////
   //
   // Get user elements we need
   //
-
-  var slice = Array.prototype.slice,
-      xmps = document.getElementsByTagName('xmp'),
+  var xmps = document.getElementsByTagName('xmp'),
       textareas = document.getElementsByTagName('textarea'),
-      markdownEls = slice.call(xmps, 0).concat(slice.call(textareas, 0)),
-      markdownEl = markdownEls[0],
+      markdownEl = xmps[0] || textareas[0],
       titleEl = document.getElementsByTagName('title')[0],
       scriptEls = document.getElementsByTagName('script'),
-      navbarEl = document.getElementsByClassName('navbar')[0];
+      navbarEl = document.getElementsByClassName('navbar')[0],
+      markdownEls = htmlCollectionToArray(xmps).concat(htmlCollectionToArray(textareas));
 
   //////////////////////////////////////////////////////////////////////
   //

--- a/src/strapdown.js
+++ b/src/strapdown.js
@@ -29,7 +29,11 @@
   // Get user elements we need
   //
 
-  var markdownEl = document.getElementsByTagName('xmp')[0] || document.getElementsByTagName('textarea')[0],
+  var slice = Array.prototype.slice,
+      xmps = document.getElementsByTagName('xmp'),
+      textareas = document.getElementsByTagName('textarea'),
+      markdownEls = slice.call(xmps, 0).concat(slice.call(textareas, 0)),
+      markdownEl = markdownEls[0],
       titleEl = document.getElementsByTagName('title')[0],
       scriptEls = document.getElementsByTagName('script'),
       navbarEl = document.getElementsByClassName('navbar')[0];
@@ -77,38 +81,57 @@
   linkEl.rel = 'stylesheet';
   document.head.appendChild(linkEl);
 
-  //////////////////////////////////////////////////////////////////////
-  //
-  // <body> stuff
-  //
+  (function markdownAll(markdownEls) {
+    var navbarAdded = false;
 
-  var markdown = markdownEl.textContent || markdownEl.innerText;
+    function addNavbar(titleEl) {
+      var newNode = document.createElement('div');
+      newNode.className = 'navbar navbar-fixed-top';
+      newNode.innerHTML = '<div class="navbar-inner"> <div class="container"> <div id="headline" class="brand"> </div> </div> </div>';
+      document.body.insertBefore(newNode, document.body.firstChild);
+      var title = titleEl.innerHTML;
+      var headlineEl = document.getElementById('headline');
+      if (headlineEl)
+        headlineEl.innerHTML = title;
+    }
 
-  var newNode = document.createElement('div');
-  newNode.className = 'container';
-  newNode.id = 'content';
-  document.body.replaceChild(newNode, markdownEl);
+    function markdownIt(markdownEl, i) {
+      //////////////////////////////////////////////////////////////////////
+      //
+      // <body> stuff
+      //
 
-  // Insert navbar if there's none
-  var newNode = document.createElement('div');
-  newNode.className = 'navbar navbar-fixed-top';
-  if (!navbarEl && titleEl) {
-    newNode.innerHTML = '<div class="navbar-inner"> <div class="container"> <div id="headline" class="brand"> </div> </div> </div>';
-    document.body.insertBefore(newNode, document.body.firstChild);
-    var title = titleEl.innerHTML;
-    var headlineEl = document.getElementById('headline');
-    if (headlineEl)
-      headlineEl.innerHTML = title;
-  }
+      var markdown = markdownEl.textContent || markdownEl.innerText;
+      // Keep existing id if present
+      var id = markdownEl.id || ('content' + i);
 
-  //////////////////////////////////////////////////////////////////////
-  //
-  // Markdown!
-  //
+      var newNode = document.createElement('div');
+      newNode.className = 'container';
+      newNode.id = id;
+      document.body.replaceChild(newNode, markdownEl);
 
-  // Generate Markdown
-  var html = marked(markdown);
-  document.getElementById('content').innerHTML = html;
+      // Insert navbar if there's none
+      if (!navbarEl && titleEl && !navbarAdded) {
+        addNavbar(titleEl);
+        navbarAdded = true;
+      }
+
+      //////////////////////////////////////////////////////////////////////
+      //
+      // Markdown!
+      //
+
+      // Generate Markdown
+      var html = marked(markdown);
+      newNode.innerHTML = html;
+    }
+
+    for (var i = 0; i < markdownEls.length; i++) {
+      if (markdownEls[i].className.split(" ").indexOf("strapdown-ignore") < 0) {
+        markdownIt(markdownEls[i], i);
+      }
+    }
+  }(markdownEls));
 
   // Prettify
   var codeEls = document.getElementsByTagName('code');


### PR DESCRIPTION
Hi,

Firstly, thanks for creating this - I've been finding it really useful.

I had a requirement to have two distinct markdown blocks on the same page, so I made these changes to iterate over all the possible elements to apply markdown to.  Very little has changed apart from wrapping a loop around some of the original code.

I've included a demo page to show what I mean.  This requires a `0.3` bundle to be generated.

I thought I'd send a pull request in case you're interested in including the changes.

Cheers.
