### PR TITLE
Allows md content to sit anywhere

### DIFF
--- a/src/strapdown.js
+++ b/src/strapdown.js
@@ -92,7 +92,7 @@
   var newNode = document.createElement('div');
   newNode.className = 'container';
   newNode.id = 'content';
-  document.body.replaceChild(newNode, markdownEl);
+  markdownEl.parentNode.replaceChild(newNode, markdownEl);
 
   // Insert navbar if there's none
   var newNode = document.createElement('div');


### PR DESCRIPTION
Allows markdown content to be the child of elements other than just
document.body. E.g. as a section of the body.
