### PR TITLE
The xmp tag doesn't have to be a child of body

### DIFF
--- a/src/strapdown.js
+++ b/src/strapdown.js
@@ -92,7 +92,7 @@
   var newNode = document.createElement('div');
   newNode.className = 'container';
   newNode.id = 'content';
-  document.body.replaceChild(newNode, markdownEl);
+  markdownEl.parentNode.replaceChild(newNode, markdownEl);
 
   // Insert navbar if there's none
   var newNode = document.createElement('div');

--- a/v/0.2/strapdown.js
+++ b/v/0.2/strapdown.js
@@ -309,9 +309,6 @@ doWork();}
 var PR=win['PR']={'createSimpleLexer':createSimpleLexer,'registerLangHandler':registerLangHandler,'sourceDecorator':sourceDecorator,'PR_ATTRIB_NAME':PR_ATTRIB_NAME,'PR_ATTRIB_VALUE':PR_ATTRIB_VALUE,'PR_COMMENT':PR_COMMENT,'PR_DECLARATION':PR_DECLARATION,'PR_KEYWORD':PR_KEYWORD,'PR_LITERAL':PR_LITERAL,'PR_NOCODE':PR_NOCODE,'PR_PLAIN':PR_PLAIN,'PR_PUNCTUATION':PR_PUNCTUATION,'PR_SOURCE':PR_SOURCE,'PR_STRING':PR_STRING,'PR_TAG':PR_TAG,'PR_TYPE':PR_TYPE,'prettyPrintOne':win['prettyPrintOne']=prettyPrintOne,'prettyPrint':win['prettyPrint']=prettyPrint};if(typeof define==="function"&&define['amd']){define("google-code-prettify",[],function(){return PR;});}})();
 ;(function(window, document) {
 
-  // Hide body until we're done fiddling with the DOM
-  document.body.style.display = 'none';
-
   //////////////////////////////////////////////////////////////////////
   //
   // Shims for IE < 9
@@ -342,6 +339,14 @@ var PR=win['PR']={'createSimpleLexer':createSimpleLexer,'registerLangHandler':re
       titleEl = document.getElementsByTagName('title')[0],
       scriptEls = document.getElementsByTagName('script'),
       navbarEl = document.getElementsByClassName('navbar')[0];
+
+  if (!markdownEl) {
+    console.warn('No embedded Markdown found in this document for Strapdown.js to work on! Visit http://strapdownjs.com/ to learn more.');
+    return;
+  }
+
+  // Hide body until we're done fiddling with the DOM
+  document.body.style.display = 'none';
 
   //////////////////////////////////////////////////////////////////////
   //
@@ -396,7 +401,7 @@ var PR=win['PR']={'createSimpleLexer':createSimpleLexer,'registerLangHandler':re
   var newNode = document.createElement('div');
   newNode.className = 'container';
   newNode.id = 'content';
-  document.body.replaceChild(newNode, markdownEl);
+  markdownEl.parentNode.replaceChild(newNode, markdownEl);
 
   // Insert navbar if there's none
   var newNode = document.createElement('div');


### PR DESCRIPTION
See issue #27

The goal is to be able to do something like:

``` html
<html>
<title>Title</title>
<body>
    <div id="main">
        <div id="sidebar"></div>
        <xmp style="display:none">
## Markdown
        </xmp>
    </div>
    <script src="strapdown/v/0.2/strapdown.js"></script>
</body>
<html>
```

Also applies changes from 40b5aa0a6125c9f529718b6fbf76ec57d16a4390 to the distributed js.
