### PR TITLE
fix spacelab theme: fetch google font via https

### DIFF
--- a/v/0.2/themes/spacelab.min.css
+++ b/v/0.2/themes/spacelab.min.css
@@ -1,4 +1,4 @@
-@import url('http://fonts.googleapis.com/css?family=Muli');
+@import url('https://fonts.googleapis.com/css?family=Muli');
 article,aside,details,figcaption,figure,footer,header,hgroup,nav,section{display:block;}
 audio,canvas,video{display:inline-block;*display:inline;*zoom:1;}
 audio:not([controls]){display:none;}


### PR DESCRIPTION
Started using strapdown over https today and immediately noticed some warnings in my browser. Twas a simple fix; all other themes are already using https.